### PR TITLE
add dispose method and tabbed view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ version = "0.4.0"
 source = "git+https://github.com/flutter-rs/flutter-rs#b6c9ddd05bc6044087cebcd156c2b2911987b18b"
 dependencies = [
  "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flutter-engine-sys 0.4.0 (git+https://github.com/flutter-rs/flutter-rs)",
+ "flutter-engine-sys 0.4.0",
  "gl 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ av-format = "0.2.0"
 av-vorbis = { git = "https://github.com/rust-av/av-vorbis" }
 cpal = { git = "https://github.com/rustaudio/cpal" }
 env_logger = "0.7.1"
-flutter-engine = { git = "https://github.com/flutter-rs/flutter-rs", features = ["gl-helpers"] }
-flutter-plugins = { git = "https://github.com/flutter-rs/flutter-rs" }
-flutter-winit = { git = "https://github.com/flutter-rs/flutter-rs" }
+# flutter-engine = { git = "https://github.com/flutter-rs/flutter-rs", features = ["gl-helpers"] }
+# flutter-plugins = { git = "https://github.com/flutter-rs/flutter-rs" }
+# flutter-winit = { git = "https://github.com/flutter-rs/flutter-rs" }
+flutter-engine = { path = "../flutter-rs/flutter-engine", features = ["gl-helpers"] }
+flutter-plugins  = { path = "../flutter-rs/flutter-plugins" }
+flutter-winit = { path = "../flutter-rs/flutter-winit" }
 glutin = { git = "https://github.com/dvc94ch/glutin", branch = "android" }
 image = "0.22.4"
 libvpx = { git = "https://github.com/rust-av/vpx-rs", features = ["codec-trait"] }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,69 +1,432 @@
-import 'package:flutter/material.dart';
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+/// An example of using the plugin, controlling lifecycle and playback of the
+/// video.
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
+import 'package:flutter/scheduler.dart';
 
-void main() {
-  // Override is necessary to prevent Unknown platform' flutter startup error.
-  debugDefaultTargetPlatformOverride = TargetPlatform.android;
-  runApp(VideoApp());
-}
+/// Controls play and pause of [controller].
+///
+/// Toggles play/pause on tap (accompanied by a fading status icon).
+///
+/// Plays (looping) on initialization, and mutes on deactivation.
+class VideoPlayPause extends StatefulWidget {
+  VideoPlayPause(this.controller);
 
-class VideoApp extends StatefulWidget {
+  final VideoPlayerController controller;
+
   @override
-  _VideoAppState createState() => _VideoAppState();
+  State createState() {
+    return _VideoPlayPauseState();
+  }
 }
 
-class _VideoAppState extends State<VideoApp> {
-  VideoPlayerController _controller;
+class _VideoPlayPauseState extends State<VideoPlayPause> {
+  _VideoPlayPauseState() {
+    listener = () {
+      SchedulerBinding.instance.addPostFrameCallback((_) => setState(() {}));
+    };
+  }
+
+  FadeAnimation imageFadeAnim =
+      FadeAnimation(child: const Icon(Icons.play_arrow, size: 100.0));
+  VoidCallback listener;
+
+  VideoPlayerController get controller => widget.controller;
 
   @override
   void initState() {
     super.initState();
-    _controller = VideoPlayerController
-      //.asset("assets/vp8_vorbis.webm")
-      .asset("assets/vp9_opus.webm")
-      //.asset("assets/bars_and_tone.webm")
-      ..initialize().then((_) {
-        // Ensure the first frame is shown after the video is initialized, even before
-        // the play button has been pressed.
-        setState(() {});
-      });
+    controller.addListener(listener);
+    controller.setVolume(1.0);
+    controller.play();
+  }
+
+  @override
+  void deactivate() {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      controller.setVolume(0.0);
+      controller.removeListener(listener);
+    });
+
+    super.deactivate();
   }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Video Demo',
-      home: Scaffold(
-        body: Center(
-          child: _controller.value.initialized
-              ? AspectRatio(
-                  aspectRatio: _controller.value.aspectRatio,
-                  child: VideoPlayer(_controller),
-                )
-              : Container(),
-        ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            setState(() {
-              _controller.setVolume(0.5);
-              _controller.value.isPlaying
-                  ? _controller.pause()
-                  : _controller.play();
-            });
-          },
-          child: Icon(
-            _controller.value.isPlaying ? Icons.pause : Icons.play_arrow,
-          ),
+    final List<Widget> children = <Widget>[
+      GestureDetector(
+        child: VideoPlayer(controller),
+        onTap: () {
+          if (!controller.value.initialized) {
+            return;
+          }
+          if (controller.value.isPlaying) {
+            imageFadeAnim =
+                FadeAnimation(child: const Icon(Icons.pause, size: 100.0));
+            controller.pause();
+          } else {
+            imageFadeAnim =
+                FadeAnimation(child: const Icon(Icons.play_arrow, size: 100.0));
+            controller.play();
+          }
+        },
+      ),
+      Align(
+        alignment: Alignment.bottomCenter,
+        child: VideoProgressIndicator(
+          controller,
+          allowScrubbing: true,
         ),
       ),
+      Center(child: imageFadeAnim),
+      Center(
+          child: controller.value.isBuffering
+              ? const CircularProgressIndicator()
+              : null),
+    ];
+
+    return Stack(
+      fit: StackFit.passthrough,
+      children: children,
     );
+  }
+}
+
+class FadeAnimation extends StatefulWidget {
+  FadeAnimation(
+      {this.child, this.duration = const Duration(milliseconds: 500)});
+
+  final Widget child;
+  final Duration duration;
+
+  @override
+  _FadeAnimationState createState() => _FadeAnimationState();
+}
+
+class _FadeAnimationState extends State<FadeAnimation>
+    with SingleTickerProviderStateMixin {
+  AnimationController animationController;
+
+  @override
+  void initState() {
+    super.initState();
+    animationController =
+        AnimationController(duration: widget.duration, vsync: this);
+    animationController.addListener(() {
+      if (mounted) {
+        setState(() {});
+      }
+    });
+    animationController.forward(from: 0.0);
+  }
+
+  @override
+  void deactivate() {
+    animationController.stop();
+    super.deactivate();
+  }
+
+  @override
+  void didUpdateWidget(FadeAnimation oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.child != widget.child) {
+      animationController.forward(from: 0.0);
+    }
   }
 
   @override
   void dispose() {
+    animationController.dispose();
     super.dispose();
-    _controller.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return animationController.isAnimating
+        ? Opacity(
+            opacity: 1.0 - animationController.value,
+            child: widget.child,
+          )
+        : Container();
+  }
+}
+
+typedef Widget VideoWidgetBuilder(
+    BuildContext context, VideoPlayerController controller);
+
+abstract class PlayerLifeCycle extends StatefulWidget {
+  PlayerLifeCycle(this.dataSource, this.childBuilder);
+
+  final VideoWidgetBuilder childBuilder;
+  final String dataSource;
+}
+
+/// A widget connecting its life cycle to a [VideoPlayerController] using
+/// a data source from the network.
+class NetworkPlayerLifeCycle extends PlayerLifeCycle {
+  NetworkPlayerLifeCycle(String dataSource, VideoWidgetBuilder childBuilder)
+      : super(dataSource, childBuilder);
+
+  @override
+  _NetworkPlayerLifeCycleState createState() => _NetworkPlayerLifeCycleState();
+}
+
+/// A widget connecting its life cycle to a [VideoPlayerController] using
+/// an asset as data source
+class AssetPlayerLifeCycle extends PlayerLifeCycle {
+  AssetPlayerLifeCycle(String dataSource, VideoWidgetBuilder childBuilder)
+      : super(dataSource, childBuilder);
+
+  @override
+  _AssetPlayerLifeCycleState createState() => _AssetPlayerLifeCycleState();
+}
+
+abstract class _PlayerLifeCycleState extends State<PlayerLifeCycle> {
+  VideoPlayerController controller;
+
+  @override
+
+  /// Subclasses should implement [createVideoPlayerController], which is used
+  /// by this method.
+  void initState() {
+    super.initState();
+    controller = createVideoPlayerController();
+    controller.addListener(() {
+      if (controller.value.hasError) {
+        print(controller.value.errorDescription);
+      }
+    });
+    controller.initialize();
+    controller.setLooping(true);
+    controller.play();
+  }
+
+  @override
+  void deactivate() {
+    super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.childBuilder(context, controller);
+  }
+
+  VideoPlayerController createVideoPlayerController();
+}
+
+class _NetworkPlayerLifeCycleState extends _PlayerLifeCycleState {
+  @override
+  VideoPlayerController createVideoPlayerController() {
+    return VideoPlayerController.network(widget.dataSource);
+  }
+}
+
+class _AssetPlayerLifeCycleState extends _PlayerLifeCycleState {
+  @override
+  VideoPlayerController createVideoPlayerController() {
+    return VideoPlayerController.asset(widget.dataSource);
+  }
+}
+
+class AspectRatioVideo extends StatefulWidget {
+  AspectRatioVideo(this.controller);
+
+  final VideoPlayerController controller;
+
+  @override
+  AspectRatioVideoState createState() => AspectRatioVideoState();
+}
+
+class AspectRatioVideoState extends State<AspectRatioVideo> {
+  VideoPlayerController get controller => widget.controller;
+  bool initialized = false;
+
+  VoidCallback listener;
+
+  @override
+  void initState() {
+    super.initState();
+    listener = () {
+      if (!mounted) {
+        return;
+      }
+      if (initialized != controller.value.initialized) {
+        initialized = controller.value.initialized;
+        setState(() {});
+      }
+    };
+    controller.addListener(listener);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (initialized) {
+      return Center(
+        child: AspectRatio(
+          aspectRatio: controller.value.aspectRatio,
+          child: VideoPlayPause(controller),
+        ),
+      );
+    } else {
+      return Container();
+    }
+  }
+}
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        key: const ValueKey<String>('home_page'),
+        appBar: AppBar(
+          title: const Text('Video player example'),
+          actions: <Widget>[
+            IconButton(
+              key: const ValueKey<String>('push_tab'),
+              icon: const Icon(Icons.navigation),
+              onPressed: () {
+                Navigator.push<PlayerVideoAndPopPage>(
+                  context,
+                  MaterialPageRoute<PlayerVideoAndPopPage>(
+                      builder: (BuildContext context) =>
+                          PlayerVideoAndPopPage()),
+                );
+              },
+            )
+          ],
+          bottom: const TabBar(
+            isScrollable: true,
+            tabs: <Widget>[
+              Tab(icon: Icon(Icons.insert_drive_file), text: "Asset"),
+              Tab(icon: Icon(Icons.list), text: "List example"),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: <Widget>[
+            SingleChildScrollView(
+              child: Column(
+                children: <Widget>[
+                  Container(
+                    padding: const EdgeInsets.only(top: 20.0),
+                  ),
+                  const Text('With assets mp4'),
+                  Container(
+                    padding: const EdgeInsets.all(20),
+                    child: AssetPlayerLifeCycle(
+                        'assets/cilla_black_bean_sauce_vp9.webm',
+                        (BuildContext context,
+                                VideoPlayerController controller) =>
+                            AspectRatioVideo(controller)),
+                  ),
+                ],
+              ),
+            ),
+            SingleChildScrollView(
+              child: Column(
+                children: <Widget>[
+                  Container(
+                    padding: const EdgeInsets.only(top: 20.0),
+                  ),
+                  const Text('With assets mp4'),
+                  Container(
+                    padding: const EdgeInsets.all(20),
+                    child: AssetPlayerLifeCycle(
+                        'assets/cilla_black_bean_sauce_vp9.webm',
+                        (BuildContext context,
+                                VideoPlayerController controller) =>
+                            AspectRatioVideo(controller)),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+
+  runApp(
+    MaterialApp(
+      home: App(),
+    ),
+  );
+}
+
+class PlayerVideoAndPopPage extends StatefulWidget {
+  @override
+  _PlayerVideoAndPopPageState createState() => _PlayerVideoAndPopPageState();
+}
+
+class _PlayerVideoAndPopPageState extends State<PlayerVideoAndPopPage> {
+  VideoPlayerController _videoPlayerController;
+  bool startedPlaying = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _videoPlayerController =
+        VideoPlayerController.asset('assets/Butterfly-209.mp4');
+    _videoPlayerController.addListener(() {
+      if (startedPlaying && !_videoPlayerController.value.isPlaying) {
+        Navigator.pop(context);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _videoPlayerController.dispose();
+    super.dispose();
+  }
+
+  Future<bool> started() async {
+    await _videoPlayerController.initialize();
+    await _videoPlayerController.play();
+    startedPlaying = true;
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      elevation: 0,
+      child: Center(
+        child: FutureBuilder<bool>(
+          future: started(),
+          builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+            if (snapshot.data == true) {
+              return AspectRatio(
+                  aspectRatio: _videoPlayerController.value.aspectRatio,
+                  child: VideoPlayer(_videoPlayerController));
+            } else {
+              return const Text('waiting for video to load');
+            }
+          },
+        ),
+      ),
+    );
   }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -115,6 +115,14 @@ impl MethodCallHandler for Handler {
                 stream.read().unwrap().player.seek_to(args.location);
                 Ok(Value::Null)
             }
+            "dispose" => {
+                let args: TextureIdArgs = from_value(&call.args)?;
+                let texture_id = &args.texture_id;
+                let channel = format!("{}/videoEvents{}", CHANNEL_NAME, texture_id);
+                self.streams.remove(texture_id).ok_or(InvalidTextureId)?;
+                engine.remove_channel(&channel);
+                Ok(Value::Null)
+            }
             _ => Err(MethodCallError::NotImplemented),
         }
     }


### PR DESCRIPTION
I added the tabbed view to test out disposing the video buffer. The player doesn't seem to have the same memory leak issues as in the golang video_player_plugin, but for some reason my cpu usage spikes up. To reproduce, click back and forth from tab to tab.